### PR TITLE
Docs: Fix cd command in README Usage Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The project adopts a modular architecture, ensuring that each component has a cl
 ### 1. Clone the repository:
 ```bash
 git clone https://github.com/Vyzer9/C2-Educational-Steganography.git
-cd Educational-C2-Steganography
+cd C2-Educational-Steganography
 ```
 ### 2. Install dependencies
 ```bash


### PR DESCRIPTION
This PR fixes a typo in the `cd` command within the `README.md` file.

The `git clone` command creates the `C2-Educational-Steganography` directory, but the next command was trying to access `Educational-C2-Steganography`. This change corrects the path to ensure the setup instructions work as expected.